### PR TITLE
Adopt wheezy fixes (several CVEs and few bugs):

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,99 @@
+curl (7.26.0-1maemo1+0cssu3) unstable; urgency=high
+
+  * Fix CVE-2016-5419: TLS session resumption client cert bypass.
+  * Fix CVE-2016-5420: Re-using connection with wrong client cert.
+  * Fix CVE-2016-7141: Incorrect reuse of client certificates (Closes:
+    #836918)
+  * Fix CVE-2016-7167: Curl escape/unescape integer overflows (closes:
+    #837945)
+  * CVE-2016-8615
+    If cookie state is written into a cookie jar file that is later read
+    back and used for subsequent requests, a malicious HTTP server can
+    inject new cookies for arbitrary domains into said cookie jar.
+    The issue pertains to the function that loads cookies into memory, which
+    reads the specified file into a fixed-size buffer in a line-by-line
+    manner using the `fgets()` function. If an invocation of fgets() cannot
+    read the whole line into the destination buffer due to it being too
+    small, it truncates the output.
+    This way, a very long cookie (name + value) sent by a malicious server
+    would be stored in the file and subsequently that cookie could be read
+    partially and crafted correctly, it could be treated as a different
+    cookie for another server.
+  * CVE-2016-8616
+    When re-using a connection, curl was doing case insensitive comparisons
+    of user name and password with the existing connections.
+    This means that if an unused connection with proper credentials exists
+    for a protocol that has connection-scoped credentials, an attacker can
+    cause that connection to be reused if s/he knows the case-insensitive
+    version of the correct password.
+  * CVE-2016-8617
+    In libcurl's base64 encode function, the output buffer is allocated
+    as follows without any checks on insize:
+       malloc( insize * 4 / 3 + 4 )
+    On systems with 32-bit addresses in userspace (e.g. x86, ARM, x32),
+    the multiplication in the expression wraps around if insize is at
+    least 1GB of data. If this happens, an undersized output buffer will
+    be allocated, but the full result will be written, thus causing the
+    memory behind the output buffer to be overwritten.
+    Systems with 64 bit versions of the `size_t` type are not affected
+    by this issue.
+  * CVE-2016-8618
+    The libcurl API function called `curl_maprintf()` can be tricked into
+    doing a double-free due to an unsafe `size_t` multiplication, on
+    systems using 32 bit `size_t` variables. The function is also used
+    internallty in numerous situations.
+    Systems with 64 bit versions of the `size_t` type are not affected
+    by this issue.
+  * CVE-2016-8619
+    In curl's implementation of the Kerberos authentication mechanism,
+    the function `read_data()` in security.c is used to fill the
+    necessary krb5 structures. When reading one of the length fields from
+    the socket, it fails to ensure that the length parameter passed to
+    realloc() is not set to 0.
+  * CVE-2016-8621
+    The `curl_getdate` converts a given date string into a numerical
+    timestamp and it supports a range of different formats and
+    possibilites to express a date and time. The underlying date
+    parsing function is also used internally when parsing for example
+    HTTP cookies (possibly received from remote servers) and it can be
+    used when doing conditional HTTP requests.
+  * CVE-2016-8622
+    The URL percent-encoding decode function in libcurl is called
+    `curl_easy_unescape`. Internally, even if this function would be
+    made to allocate a unscape destination buffer larger than 2GB, it
+    would return that new length in a signed 32 bit integer variable,
+    thus the length would get either just truncated or both truncated
+    and turned negative. That could then lead to libcurl writing outside
+    of its heap based buffer.
+  * CVE-2016-8623 9/11 curl Use-after-free via shared cookies
+    libcurl explicitly allows users to share cookies between multiple
+    easy handles that are concurrently employed by different threads.
+    When cookies to be sent to a server are collected, the matching
+    function collects all cookies to send and the cookie lock is released
+    immediately afterwards. That funcion however only returns a list with
+    *references* back to the original strings for name, value, path and so
+    on. Therefore, if another thread quickly takes the lock and frees one
+    of the original cookie structs together with its strings,
+    a use-after-free can occur and lead to information disclosure. Another
+    thread can also replace the contents of the cookies from separate HTTP
+    responses or API calls.
+  * CVE-2016-8624 10/11 curl invalid URL parsing with '#'
+    curl doesn't parse the authority component of the URL correctly when
+    the host name part ends with a '#' character, and could instead be
+    tricked into connecting to a different host. This may have security
+    implications if you for example use an URL parser that follows the RFC
+    to check for allowed domains before using curl to request them.
+  * CVE-2016-9586
+    libcurl's implementation of the printf() functions triggers a buffer
+    overflow when doing a large floating point output. The bug occurs
+    when the conversion outputs more than 255 bytes.
+    If there are any application that accepts a format string from the outside
+    without necessary input filtering, it could allow remote attacks.
+    This flaw does not exist in the command line tool.
+    (Closes: #848958)
+
+ -- Ludek Finstrle <luf@seznam.cz>  Sun, 15 Jan 2017 14:48:03 +0100
+
 curl (7.26.0-1maemo1+0cssu2) unstable; urgency=high
 
   * Fix buffer overflow when negotiating SMTP DIGEST-MD5 authentication

--- a/debian/patches/CVE-2016-5419.patch
+++ b/debian/patches/CVE-2016-5419.patch
@@ -1,0 +1,65 @@
+From: Markus Koschany <apo@debian.org>
+Date: Thu, 4 Aug 2016 11:32:30 +0200
+Subject: CVE-2016-5419
+
+Fix TLS session resumption client cert bypass.
+
+Origin: https://curl.haxx.se/CVE-2016-5419.patch
+---
+ lib/sslgen.c  | 10 ++++++++++
+ lib/url.c     |  1 +
+ lib/urldata.h |  1 +
+ 3 files changed, 12 insertions(+)
+
+diff --git a/lib/sslgen.c b/lib/sslgen.c
+index a77fd78..6f19793 100644
+--- a/lib/sslgen.c
++++ b/lib/sslgen.c
+@@ -147,6 +147,15 @@ Curl_clone_ssl_config(struct ssl_config_data *source,
+   else
+     dest->random_file = NULL;
+ 
++  if(source->clientcert) {
++    dest->clientcert = strdup(source->clientcert);
++    if(!dest->clientcert)
++      return FALSE;
++    dest->sessionid = FALSE;
++  }
++  else
++    dest->clientcert = NULL;
++
+   return TRUE;
+ }
+ 
+@@ -157,6 +166,7 @@ void Curl_free_ssl_config(struct ssl_config_data* sslc)
+   Curl_safefree(sslc->cipher_list);
+   Curl_safefree(sslc->egdsocket);
+   Curl_safefree(sslc->random_file);
++  Curl_safefree(sslc->clientcert);
+ }
+ 
+ #ifdef USE_SSL
+diff --git a/lib/url.c b/lib/url.c
+index 26ca765..90a4442 100644
+--- a/lib/url.c
++++ b/lib/url.c
+@@ -5121,6 +5121,7 @@ static CURLcode create_conn(struct SessionHandle *data,
+   data->set.ssl.random_file = data->set.str[STRING_SSL_RANDOM_FILE];
+   data->set.ssl.egdsocket = data->set.str[STRING_SSL_EGDSOCKET];
+   data->set.ssl.cipher_list = data->set.str[STRING_SSL_CIPHER_LIST];
++  data->set.ssl.clientcert = data->set.str[STRING_CERT];
+ #ifdef USE_TLS_SRP
+   data->set.ssl.username = data->set.str[STRING_TLSAUTH_USERNAME];
+   data->set.ssl.password = data->set.str[STRING_TLSAUTH_PASSWORD];
+diff --git a/lib/urldata.h b/lib/urldata.h
+index 13a03ae..74f5b57 100644
+--- a/lib/urldata.h
++++ b/lib/urldata.h
+@@ -295,6 +295,7 @@ struct ssl_config_data {
+   char *CAfile;          /* certificate to verify peer against */
+   const char *CRLfile;   /* CRL to check certificate revocation */
+   const char *issuercert;/* optional issuer certificate filename */
++  char *clientcert;
+   char *random_file;     /* path to file containing "random" data */
+   char *egdsocket;       /* path to file containing the EGD daemon socket */
+   char *cipher_list;     /* list of ciphers to use */

--- a/debian/patches/CVE-2016-5420.patch
+++ b/debian/patches/CVE-2016-5420.patch
@@ -1,0 +1,23 @@
+From: Markus Koschany <apo@debian.org>
+Date: Thu, 4 Aug 2016 11:33:57 +0200
+Subject: CVE-2016-5420
+
+Fix Re-using connection with wrong client cert.
+
+Origin: https://curl.haxx.se/CVE-2016-5420.patch
+---
+ lib/sslgen.c | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/lib/sslgen.c b/lib/sslgen.c
+index 6f19793..a143b72 100644
+--- a/lib/sslgen.c
++++ b/lib/sslgen.c
+@@ -90,6 +90,7 @@ Curl_ssl_config_matches(struct ssl_config_data* data,
+      (data->verifyhost == needle->verifyhost) &&
+      safe_strequal(data->CApath, needle->CApath) &&
+      safe_strequal(data->CAfile, needle->CAfile) &&
++     safe_strequal(data->clientcert, needle->clientcert) &&
+      safe_strequal(data->random_file, needle->random_file) &&
+      safe_strequal(data->egdsocket, needle->egdsocket) &&
+      safe_strequal(data->cipher_list, needle->cipher_list))

--- a/debian/patches/CVE-2016-7141.patch
+++ b/debian/patches/CVE-2016-7141.patch
@@ -1,0 +1,37 @@
+From 7700fcba64bf5806de28f6c1c7da3b4f0b38567d Mon Sep 17 00:00:00 2001
+From: Kamil Dudka <kdudka@redhat.com>
+Date: Mon, 22 Aug 2016 10:24:35 +0200
+Subject: [PATCH] nss: refuse previously loaded certificate from file
+
+... when we are not asked to use a certificate from file
+
+Origin: upstream
+Reviewed-by: Balint Reczey <balint@balintreczey.hu>
+
+--- a/lib/nss.c
++++ b/lib/nss.c
+@@ -779,10 +779,10 @@
+   struct ssl_connect_data *connssl = (struct ssl_connect_data *)arg;
+   struct SessionHandle *data = connssl->data;
+   const char *nickname = connssl->client_nickname;
++  static const char pem_slotname[] = "PEM Token #1";
+ 
+   if(connssl->obj_clicert) {
+     /* use the cert/key provided by PEM reader */
+-    static const char pem_slotname[] = "PEM Token #1";
+     SECItem cert_der = { 0, NULL, 0 };
+     void *proto_win = SSL_RevealPinArg(sock);
+ 
+@@ -839,6 +839,12 @@
+   if(NULL == nickname)
+     nickname = "[unknown]";
+ 
++  if(!strncmp(nickname, pem_slotname, sizeof(pem_slotname) - 1U)) {
++    failf(data, "NSS: refusing previously loaded certificate from file: %s",
++          nickname);
++    return SECFailure;
++  }
++
+   if(NULL == *pRetKey) {
+     failf(data, "NSS: private key not found for certificate: %s", nickname);
+     return SECFailure;

--- a/debian/patches/CVE-2016-7167.patch
+++ b/debian/patches/CVE-2016-7167.patch
@@ -1,0 +1,60 @@
+From: Jonas Meurer <mejo@debian.org>
+Date: Sat, 17 Sep 2016 18:14:07 +0200
+Subject: [PATCH] CVE-2016-7167: deny negative string length inputs
+
+Bug: https://curl.haxx.se/docs/adv_20160914.html
+
+This patch is backported from upstream fix by Daniel Stenberg in
+git commit bf0bb3849422c043f21f56fae57c1cf85e41a272.
+
+--- a/lib/escape.c	2016-09-17 02:02:17.000000000 +0200
++++ b/lib/escape.c	2016-09-17 18:08:40.264762843 +0200
+@@ -80,15 +80,21 @@
+ 
+ char *curl_easy_escape(CURL *handle, const char *string, int inlength)
+ {
+-  size_t alloc = (inlength?(size_t)inlength:strlen(string))+1;
++  size_t alloc;
+   char *ns;
+   char *testing_ptr = NULL;
+   unsigned char in; /* we need to treat the characters unsigned */
+-  size_t newlen = alloc;
++  size_t newlen;
+   size_t strindex=0;
+   size_t length;
+   CURLcode res;
+ 
++  if(inlength < 0)
++    return NULL;
++
++  alloc = (inlength?(size_t)inlength:strlen(string))+1;
++  newlen = alloc;
++
+   ns = malloc(alloc);
+   if(!ns)
+     return NULL;
+@@ -213,14 +219,16 @@
+                          int *olen)
+ {
+   char *str = NULL;
+-  size_t inputlen = length;
+-  size_t outputlen;
+-  CURLcode res = Curl_urldecode(handle, string, inputlen, &str, &outputlen,
+-                                FALSE);
+-  if(res)
+-    return NULL;
+-  if(olen)
+-    *olen = curlx_uztosi(outputlen);
++  if(length >= 0) {
++    size_t inputlen = length;
++    size_t outputlen;
++    CURLcode res = Curl_urldecode(handle, string, inputlen, &str, &outputlen,
++                                  FALSE);
++    if(res)
++      return NULL;
++    if(olen)
++      *olen = curlx_uztosi(outputlen);
++  }
+   return str;
+ }
+ 

--- a/debian/patches/CVE-2016-8615.patch
+++ b/debian/patches/CVE-2016-8615.patch
@@ -1,0 +1,59 @@
+From 28867c2eb601e96a9205cce962b4898c4b9118de Mon Sep 17 00:00:00 2001
+From: Daniel Stenberg <daniel@haxx.se>
+Date: Tue, 27 Sep 2016 17:36:19 +0200
+Subject: [PATCH] cookie: replace use of fgets() with custom version
+
+... that will ignore lines that are too long to fit in the buffer.
+---
+ lib/cookie.c | 31 ++++++++++++++++++++++++++++++-
+ 1 file changed, 30 insertions(+), 1 deletion(-)
+
+Index: curl-7.26.0/lib/cookie.c
+===================================================================
+--- curl-7.26.0.orig/lib/cookie.c	2016-11-01 11:16:33.800786985 +0100
++++ curl-7.26.0/lib/cookie.c	2016-11-01 11:18:08.922181201 +0100
+@@ -740,6 +740,35 @@
+   return co;
+ }
+ 
++/*
++ * get_line() makes sure to only return complete whole lines that fit in 'len'
++ * bytes and end with a newline.
++ */
++static char *get_line(char *buf, int len, FILE *input)
++{
++  bool partial = FALSE;
++  while(1) {
++    char *b = fgets(buf, len, input);
++    if(b) {
++      size_t rlen = strlen(b);
++      if(rlen && (b[rlen-1] == '\n')) {
++        if(partial) {
++          partial = FALSE;
++          continue;
++        }
++        return b;
++      }
++      else
++        /* read a partial, discard the next piece that ends with newline */
++        partial = TRUE;
++    }
++    else
++      break;
++  }
++  return NULL;
++}
++
++
+ /*****************************************************************************
+  *
+  * Curl_cookie_init()
+@@ -791,7 +820,7 @@
+ 
+     char *line = malloc(MAX_COOKIE_LINE);
+     if(line) {
+-      while(fgets(line, MAX_COOKIE_LINE, fp)) {
++      while(get_line(line, MAX_COOKIE_LINE, fp)) {
+         if(checkprefix("Set-Cookie:", line)) {
+           /* This is a cookie line, get it! */
+           lineptr=&line[11];

--- a/debian/patches/CVE-2016-8616.patch
+++ b/debian/patches/CVE-2016-8616.patch
@@ -1,0 +1,25 @@
+From 62fd988392b5a0410a01a9d8f3c470280350b4c5 Mon Sep 17 00:00:00 2001
+From: Daniel Stenberg <daniel@haxx.se>
+Date: Tue, 27 Sep 2016 18:01:53 +0200
+Subject: [PATCH] connectionexists: use case sensitive user/password
+ comparisons
+
+---
+ lib/url.c | 12 ++++++------
+ 1 file changed, 6 insertions(+), 6 deletions(-)
+
+Index: curl-7.26.0/lib/url.c
+===================================================================
+--- curl-7.26.0.orig/lib/url.c	2016-11-01 11:35:37.021467479 +0100
++++ curl-7.26.0/lib/url.c	2016-11-01 11:36:20.496276380 +0100
+@@ -3120,8 +3120,8 @@
+             check->ntlm.state != NTLMSTATE_NONE)) {
+           /* This protocol requires credentials per connection or is HTTP+NTLM,
+              so verify that we're using the same name and password as well */
+-          if(!strequal(needle->user, check->user) ||
+-             !strequal(needle->passwd, check->passwd)) {
++          if(strcmp(needle->user, check->user) ||
++             strcmp(needle->passwd, check->passwd)) {
+             /* one of them was different */
+             continue;
+           }

--- a/debian/patches/CVE-2016-8617.patch
+++ b/debian/patches/CVE-2016-8617.patch
@@ -1,0 +1,25 @@
+From 32ae8ba41b5dbf26dabe884ac4aa12597d1d96b9 Mon Sep 17 00:00:00 2001
+From: Daniel Stenberg <daniel@haxx.se>
+Date: Wed, 28 Sep 2016 00:05:12 +0200
+Subject: [PATCH] base64: check for integer overflow on large input
+
+---
+ lib/base64.c | 5 +++++
+ 1 file changed, 5 insertions(+)
+
+Index: curl-7.26.0/lib/base64.c
+===================================================================
+--- curl-7.26.0.orig/lib/base64.c	2016-11-01 11:46:30.911544345 +0100
++++ curl-7.26.0/lib/base64.c	2016-11-01 11:47:20.838175826 +0100
+@@ -176,6 +176,11 @@
+   if(0 == insize)
+     insize = strlen(indata);
+ 
++#if SIZEOF_SIZE_T == 4
++  if(insize > UINT_MAX/4)
++    return CURLE_OUT_OF_MEMORY;
++#endif
++
+   base64data = output = malloc(insize*4/3+4);
+   if(NULL == output)
+     return CURLE_OUT_OF_MEMORY;

--- a/debian/patches/CVE-2016-8618.patch
+++ b/debian/patches/CVE-2016-8618.patch
@@ -1,0 +1,38 @@
+From bf952ecb87276a1f782c07d1ca229717fff31fb4 Mon Sep 17 00:00:00 2001
+From: Daniel Stenberg <daniel@haxx.se>
+Date: Wed, 28 Sep 2016 10:15:34 +0200
+Subject: [PATCH] aprintf: detect wrap-around when growing allocation
+
+On 32bit systems we could otherwise wrap around after 2GB and allocate 0
+bytes and crash.
+---
+ lib/mprintf.c | 9 ++++++---
+ 1 file changed, 6 insertions(+), 3 deletions(-)
+
+Index: curl-7.26.0/lib/mprintf.c
+===================================================================
+--- curl-7.26.0.orig/lib/mprintf.c	2016-11-01 11:56:28.819153537 +0100
++++ curl-7.26.0/lib/mprintf.c	2016-11-01 11:56:28.815153647 +0100
+@@ -1066,16 +1066,19 @@
+     infop->len =0;
+   }
+   else if(infop->len+1 >= infop->alloc) {
+-    char *newptr;
++    char *newptr = NULL;
++    size_t newsize = infop->alloc*2;
+ 
+-    newptr = realloc(infop->buffer, infop->alloc*2);
++    /* detect wrap-around or other overflow problems */
++    if(newsize > infop->alloc)
++      newptr = realloc(infop->buffer, newsize);
+ 
+     if(!newptr) {
+       infop->fail = 1;
+       return -1; /* fail */
+     }
+     infop->buffer = newptr;
+-    infop->alloc *= 2;
++    infop->alloc = newsize;
+   }
+ 
+   infop->buffer[ infop->len ] = outc;

--- a/debian/patches/CVE-2016-8619.patch
+++ b/debian/patches/CVE-2016-8619.patch
@@ -1,0 +1,39 @@
+From 6c1811521c5f6453e0a1a492522c2e421da356bf Mon Sep 17 00:00:00 2001
+From: Daniel Stenberg <daniel@haxx.se>
+Date: Wed, 28 Sep 2016 12:56:02 +0200
+Subject: [PATCH] krb5: avoid realloc(0)
+
+If the requested size is zero, bail out with error instead of doing a
+realloc() that would cause a double-free: realloc(0) acts as a free()
+and then there's a second free in the cleanup path.
+---
+ lib/security.c | 9 ++++++---
+ 1 file changed, 6 insertions(+), 3 deletions(-)
+
+Index: curl-7.26.0/lib/security.c
+===================================================================
+--- curl-7.26.0.orig/lib/security.c	2016-11-01 12:12:15.005205865 +0100
++++ curl-7.26.0/lib/security.c	2016-11-01 12:13:09.575710711 +0100
+@@ -206,15 +206,19 @@
+                           struct krb4buffer *buf)
+ {
+   int len;
+-  void* tmp;
++  void* tmp = NULL;
+   CURLcode ret;
+ 
+   ret = socket_read(fd, &len, sizeof(len));
+   if(ret != CURLE_OK)
+     return ret;
+ 
+-  len = ntohl(len);
+-  tmp = realloc(buf->data, len);
++  if(len) {
++    /* only realloc if there was a length */
++    len = ntohl(len);
++    tmp = realloc(buf->data, len);
++  }
++
+   if(tmp == NULL)
+     return CURLE_OUT_OF_MEMORY;
+ 

--- a/debian/patches/CVE-2016-8620.patch
+++ b/debian/patches/CVE-2016-8620.patch
@@ -1,0 +1,161 @@
+From 4c402fb6dbb7a56e343ea1bd83f5b5d98760db04 Mon Sep 17 00:00:00 2001
+From: Daniel Stenberg <daniel@haxx.se>
+Date: Mon, 3 Oct 2016 17:27:16 +0200
+Subject: [PATCH] globbing: prevent out of bounds accesses
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Reported-by: Luật Nguyễn
+---
+ src/tool_urlglob.c | 58 ++++++++++++++++++++++++++++++++++--------------------
+ 1 file changed, 37 insertions(+), 21 deletions(-)
+
+diff --git a/src/tool_urlglob.c b/src/tool_urlglob.c
+index a357b8b..09d21b6 100644
+--- a/src/tool_urlglob.c
++++ b/src/tool_urlglob.c
+@@ -186,36 +186,40 @@ static CURLcode glob_range(URLGlob *glob, char **patternp,
+ 
+   if(ISALPHA(*pattern)) {
+     /* character range detected */
+     char min_c;
+     char max_c;
++    char end_c;
+     int step=1;
+ 
+     pat->type = UPTCharRange;
+ 
+-    rc = sscanf(pattern, "%c-%c", &min_c, &max_c);
++    rc = sscanf(pattern, "%c-%c%c", &min_c, &max_c, &end_c);
+ 
+-    if((rc == 2) && (pattern[3] == ':')) {
+-      char *endp;
+-      unsigned long lstep;
+-      errno = 0;
+-      lstep = strtoul(&pattern[4], &endp, 10);
+-      if(errno || (*endp != ']'))
+-        step = -1;
+-      else {
+-        pattern = endp+1;
+-        step = (int)lstep;
+-        if(step > (max_c - min_c))
++    if(rc == 3) {
++      if(end_c == ':') {
++        char *endp;
++        unsigned long lstep;
++        errno = 0;
++        lstep = strtoul(&pattern[4], &endp, 10);
++        if(errno || (*endp != ']'))
+           step = -1;
++        else {
++          pattern = endp+1;
++          step = (int)lstep;
++          if(step > (max_c - min_c))
++            step = -1;
++        }
+       }
++      else if(end_c != ']')
++        /* then this is wrong */
++        rc = 0;
+     }
+-    else
+-      pattern += 4;
+ 
+     *posp += (pattern - *patternp);
+ 
+-    if((rc != 2) || (min_c >= max_c) || ((max_c - min_c) > ('z' - 'a')) ||
++    if((rc != 3) || (min_c >= max_c) || ((max_c - min_c) > ('z' - 'a')) ||
+        (step <= 0) )
+       /* the pattern is not well-formed */
+       return GLOBERROR("bad range", *posp, CURLE_URL_MALFORMAT);
+ 
+     /* if there was a ":[num]" thing, use that as step or else use 1 */
+@@ -255,10 +259,16 @@ static CURLcode glob_range(URLGlob *glob, char **patternp,
+     else {
+       if(*endp != '-')
+         endp = NULL;
+       else {
+         pattern = endp+1;
++        while(*pattern && ISBLANK(*pattern))
++          pattern++;
++        if(!ISDIGIT(*pattern)) {
++          endp = NULL;
++          goto fail;
++        }
+         errno = 0;
+         max_n = strtoul(pattern, &endp, 10);
+         if(errno || (*endp == ':')) {
+           pattern = endp+1;
+           errno = 0;
+@@ -275,10 +285,11 @@ static CURLcode glob_range(URLGlob *glob, char **patternp,
+         else
+           endp = NULL;
+       }
+     }
+ 
++    fail:
+     *posp += (pattern - *patternp);
+ 
+     if(!endp || (min_n > max_n) || (step_n > (max_n - min_n)) || !step_n)
+       /* the pattern is not well-formed */
+       return GLOBERROR("bad range", *posp, CURLE_URL_MALFORMAT);
+@@ -422,10 +433,11 @@ CURLcode glob_url(URLGlob** glob, char* url, unsigned long *urlnum,
+   *glob = NULL;
+ 
+   glob_buffer = malloc(strlen(url) + 1);
+   if(!glob_buffer)
+     return CURLE_OUT_OF_MEMORY;
++  glob_buffer[0]=0;
+ 
+   glob_expand = calloc(1, sizeof(URLGlob));
+   if(!glob_expand) {
+     Curl_safefree(glob_buffer);
+     return CURLE_OUT_OF_MEMORY;
+@@ -539,33 +551,37 @@ CURLcode glob_next_url(char **globbed, URLGlob *glob)
+   for(i = 0; i < glob->size; ++i) {
+     pat = &glob->pattern[i];
+     switch(pat->type) {
+     case UPTSet:
+       if(pat->content.Set.elements) {
+-        len = strlen(pat->content.Set.elements[pat->content.Set.ptr_s]);
+         snprintf(buf, buflen, "%s",
+                  pat->content.Set.elements[pat->content.Set.ptr_s]);
++        len = strlen(buf);
+         buf += len;
+         buflen -= len;
+       }
+       break;
+     case UPTCharRange:
+-      *buf++ = pat->content.CharRange.ptr_c;
++      if(buflen) {
++        *buf++ = pat->content.CharRange.ptr_c;
++        *buf = '\0';
++        buflen--;
++      }
+       break;
+     case UPTNumRange:
+-      len = snprintf(buf, buflen, "%0*ld",
+-                     pat->content.NumRange.padlength,
+-                     pat->content.NumRange.ptr_n);
++      snprintf(buf, buflen, "%0*ld",
++               pat->content.NumRange.padlength,
++               pat->content.NumRange.ptr_n);
++      len = strlen(buf);
+       buf += len;
+       buflen -= len;
+       break;
+     default:
+       printf("internal error: invalid pattern type (%d)\n", (int)pat->type);
+       return CURLE_FAILED_INIT;
+     }
+   }
+-  *buf = '\0';
+ 
+   *globbed = strdup(glob->glob_buffer);
+   if(!*globbed)
+     return CURLE_OUT_OF_MEMORY;
+ 
+-- 
+2.9.3
+

--- a/debian/patches/CVE-2016-8621.patch
+++ b/debian/patches/CVE-2016-8621.patch
@@ -1,0 +1,86 @@
+From b49dcc911ba237a878dded67865e536a65bc2d87 Mon Sep 17 00:00:00 2001
+From: Daniel Stenberg <daniel@haxx.se>
+Date: Tue, 4 Oct 2016 16:59:38 +0200
+Subject: [PATCH] parsedate: handle cut off numbers better
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+... and don't read outside of the given buffer!
+
+Reported-by: Luật Nguyễn
+---
+ lib/parsedate.c        | 12 +++++++-----
+ tests/data/test517     |  6 ++++++
+ tests/libtest/lib517.c |  8 +++++++-
+ 3 files changed, 20 insertions(+), 6 deletions(-)
+
+Index: curl-7.26.0/lib/parsedate.c
+===================================================================
+--- curl-7.26.0.orig/lib/parsedate.c	2016-11-01 12:28:53.677847737 +0100
++++ curl-7.26.0/lib/parsedate.c	2016-11-01 12:28:53.673847847 +0100
+@@ -384,15 +384,17 @@
+       /* a digit */
+       int val;
+       char *end;
++      int len=0;
+       if((secnum == -1) &&
+-         (3 == sscanf(date, "%02d:%02d:%02d", &hournum, &minnum, &secnum))) {
++         (3 == sscanf(date, "%02d:%02d:%02d%n",
++                      &hournum, &minnum, &secnum, &len))) {
+         /* time stamp! */
+-        date += 8;
++        date += len;
+       }
+       else if((secnum == -1) &&
+-              (2 == sscanf(date, "%02d:%02d", &hournum, &minnum))) {
++              (2 == sscanf(date, "%02d:%02d%n", &hournum, &minnum, &len))) {
+         /* time stamp without seconds */
+-        date += 5;
++        date += len;
+         secnum = 0;
+       }
+       else {
+Index: curl-7.26.0/tests/data/test517
+===================================================================
+--- curl-7.26.0.orig/tests/data/test517	2016-11-01 12:28:53.677847737 +0100
++++ curl-7.26.0/tests/data/test517	2016-11-01 12:29:27.972908193 +0100
+@@ -110,6 +110,12 @@
+ 81: 20111323 12:34:56 => -1
+ 82: 20110623 12:34:79 => -1
+ 83: Wed, 31 Dec 2008 23:59:60 GMT => 1230768000
++84: 20110623 12:3 => 1308830580
++85: 20110623 1:3 => 1308790980
++86: 20110623 1:30 => 1308792600
++87: 20110623 12:12:3 => 1308831123
++88: 20110623 01:12:3 => 1308791523
++89: 20110623 01:99:30 => -1
+ </stdout>
+ 
+ # This test case previously testes an overflow case ("2094 Nov 6 =>
+Index: curl-7.26.0/tests/libtest/lib517.c
+===================================================================
+--- curl-7.26.0.orig/tests/libtest/lib517.c	2016-11-01 12:28:53.677847737 +0100
++++ curl-7.26.0/tests/libtest/lib517.c	2016-11-01 12:28:53.673847847 +0100
+@@ -5,7 +5,7 @@
+  *                            | (__| |_| |  _ <| |___
+  *                             \___|\___/|_| \_\_____|
+  *
+- * Copyright (C) 1998 - 2011, Daniel Stenberg, <daniel@haxx.se>, et al.
++ * Copyright (C) 1998 - 2016, Daniel Stenberg, <daniel@haxx.se>, et al.
+  *
+  * This software is licensed as described in the file COPYING, which
+  * you should have received as part of this distribution. The terms
+@@ -116,6 +116,12 @@
+   "20111323 12:34:56",
+   "20110623 12:34:79",
+   "Wed, 31 Dec 2008 23:59:60 GMT", /* leap second */
++  "20110623 12:3",
++  "20110623 1:3",
++  "20110623 1:30",
++  "20110623 12:12:3",
++  "20110623 01:12:3",
++  "20110623 01:99:30",
+   NULL
+ };
+ 

--- a/debian/patches/CVE-2016-8622.patch
+++ b/debian/patches/CVE-2016-8622.patch
@@ -1,0 +1,77 @@
+From 635590efc040a58a8ce7c9bd8ed84ff2933737cb Mon Sep 17 00:00:00 2001
+From: Daniel Stenberg <daniel@haxx.se>
+Date: Tue, 4 Oct 2016 18:56:45 +0200
+Subject: [PATCH] unescape: avoid integer overflow
+
+---
+ docs/libcurl/curl_easy_unescape.3 |  7 +++++--
+ lib/dict.c                        | 10 +++++-----
+ lib/escape.c                      | 10 ++++++++--
+ 3 files changed, 18 insertions(+), 9 deletions(-)
+
+Index: curl-7.26.0/docs/libcurl/curl_easy_unescape.3
+===================================================================
+--- curl-7.26.0.orig/docs/libcurl/curl_easy_unescape.3	2016-11-01 13:00:31.969856098 +0100
++++ curl-7.26.0/docs/libcurl/curl_easy_unescape.3	2016-11-01 13:00:31.965856208 +0100
+@@ -40,7 +40,10 @@
+ 
+ If \fBoutlength\fP is non-NULL, the function will write the length of the
+ returned string in the integer it points to. This allows an escaped string
+-containing %00 to still get used properly after unescaping.
++containing %00 to still get used properly after unescaping. Since this is a
++pointer to an \fIint\fP type, it can only return a value up to INT_MAX so no
++longer string can be unescaped if the string length is returned in this
++parameter.
+ 
+ You must \fIcurl_free(3)\fP the returned string when you're done with it.
+ .SH AVAILABILITY
+Index: curl-7.26.0/lib/dict.c
+===================================================================
+--- curl-7.26.0.orig/lib/dict.c	2016-11-01 13:00:31.969856098 +0100
++++ curl-7.26.0/lib/dict.c	2016-11-01 13:01:35.392119798 +0100
+@@ -58,7 +58,7 @@
+ #include <curl/curl.h>
+ #include "transfer.h"
+ #include "sendf.h"
+-
++#include "escape.h"
+ #include "progress.h"
+ #include "strequal.h"
+ #include "dict.h"
+@@ -106,12 +106,12 @@
+   char *newp;
+   char *dictp;
+   char *ptr;
+-  int len;
++  size_t len;
+   char byte;
+   int olen=0;
+ 
+-  newp = curl_easy_unescape(data, inputbuff, 0, &len);
+-  if(!newp)
++  CURLcode result = Curl_urldecode(data, inputbuff, 0, &newp, &len, FALSE);
++  if(!newp || result)
+     return NULL;
+ 
+   dictp = malloc(((size_t)len)*2 + 1); /* add one for terminating zero */
+Index: curl-7.26.0/lib/escape.c
+===================================================================
+--- curl-7.26.0.orig/lib/escape.c	2016-11-01 13:00:31.969856098 +0100
++++ curl-7.26.0/lib/escape.c	2016-11-01 13:00:31.965856208 +0100
+@@ -226,8 +226,14 @@
+                                   FALSE);
+     if(res)
+       return NULL;
+-    if(olen)
+-      *olen = curlx_uztosi(outputlen);
++
++    if(olen) {
++      if(outputlen <= (size_t) INT_MAX)
++        *olen = curlx_uztosi(outputlen);
++      else
++        /* too large to return in an int, fail! */
++        Curl_safefree(str);
++    }
+   }
+   return str;
+ }

--- a/debian/patches/CVE-2016-8623.patch
+++ b/debian/patches/CVE-2016-8623.patch
@@ -1,0 +1,154 @@
+From b05d7b8d8f8dd0cf717e53324af46f62b27db5ea Mon Sep 17 00:00:00 2001
+From: Daniel Stenberg <daniel@haxx.se>
+Date: Tue, 4 Oct 2016 23:26:13 +0200
+Subject: [PATCH] cookies: getlist() now holds deep copies of all cookies
+
+Previously it only held references to them, which was reckless as the
+thread lock was released so the cookies could get modified by other
+handles that share the same cookie jar over the share interface.
+---
+ lib/cookie.c | 61 +++++++++++++++++++++++++++++++++++++++---------------------
+ lib/cookie.h |  4 ++--
+ lib/http.c   |  2 +-
+ 3 files changed, 43 insertions(+), 24 deletions(-)
+
+Index: curl-7.26.0/lib/cookie.c
+===================================================================
+--- curl-7.26.0.orig/lib/cookie.c	2016-11-01 14:52:55.977049528 +0100
++++ curl-7.26.0/lib/cookie.c	2016-11-01 14:53:32.348053053 +0100
+@@ -858,6 +858,39 @@
+   return (l2 > l1) ? 1 : (l2 < l1) ? -1 : 0 ;
+ }
+ 
++#define CLONE(field)                     \
++  do {                                   \
++    if(src->field) {                     \
++      dup->field = strdup(src->field);   \
++      if(!dup->field)                    \
++        goto fail;                       \
++    }                                    \
++  } while(0)
++
++static struct Cookie *dup_cookie(struct Cookie *src)
++{
++  struct Cookie *dup = calloc(sizeof(struct Cookie), 1);
++  if(dup) {
++    CLONE(expirestr);
++    CLONE(domain);
++    CLONE(path);
++    CLONE(name);
++    CLONE(value);
++    CLONE(maxage);
++    CLONE(version);
++    dup->expires = src->expires;
++    dup->tailmatch = src->tailmatch;
++    dup->secure = src->secure;
++    dup->livecookie = src->livecookie;
++    dup->httponly = src->httponly;
++  }
++  return dup;
++
++  fail:
++  freecookie(dup);
++  return NULL;
++}
++
+ /*****************************************************************************
+  *
+  * Curl_cookie_getlist()
+@@ -913,11 +946,8 @@
+           /* and now, we know this is a match and we should create an
+              entry for the return-linked-list */
+ 
+-          newco = malloc(sizeof(struct Cookie));
++          newco = dup_cookie(co);
+           if(newco) {
+-            /* first, copy the whole source cookie: */
+-            memcpy(newco, co, sizeof(struct Cookie));
+-
+             /* then modify our next */
+             newco->next = mainco;
+ 
+@@ -929,12 +959,7 @@
+           else {
+             fail:
+             /* failure, clear up the allocated chain and return NULL */
+-            while(mainco) {
+-              co = mainco->next;
+-              free(mainco);
+-              mainco = co;
+-            }
+-
++            Curl_cookie_freelist(mainco);
+             return NULL;
+           }
+         }
+@@ -986,7 +1011,7 @@
+ void Curl_cookie_clearall(struct CookieInfo *cookies)
+ {
+   if(cookies) {
+-    Curl_cookie_freelist(cookies->cookies, TRUE);
++    Curl_cookie_freelist(cookies->cookies);
+     cookies->cookies = NULL;
+     cookies->numcookies = 0;
+   }
+@@ -998,22 +1023,15 @@
+  *
+  * Free a list of cookies previously returned by Curl_cookie_getlist();
+  *
+- * The 'cookiestoo' argument tells this function whether to just free the
+- * list or actually also free all cookies within the list as well.
+- *
+  ****************************************************************************/
+ 
+-void Curl_cookie_freelist(struct Cookie *co, bool cookiestoo)
++void Curl_cookie_freelist(struct Cookie *co)
+ {
+   struct Cookie *next;
+   if(co) {
+     while(co) {
+       next = co->next;
+-      if(cookiestoo)
+-        freecookie(co);
+-      else
+-        free(co); /* we only free the struct since the "members" are all just
+-                     pointed out in the main cookie list! */
++      freecookie(co);
+       co = next;
+     }
+   }
+Index: curl-7.26.0/lib/cookie.h
+===================================================================
+--- curl-7.26.0.orig/lib/cookie.h	2016-11-01 14:52:55.977049528 +0100
++++ curl-7.26.0/lib/cookie.h	2016-11-01 14:52:55.973049638 +0100
+@@ -7,7 +7,7 @@
+  *                            | (__| |_| |  _ <| |___
+  *                             \___|\___/|_| \_\_____|
+  *
+- * Copyright (C) 1998 - 2011, Daniel Stenberg, <daniel@haxx.se>, et al.
++ * Copyright (C) 1998 - 2016, Daniel Stenberg, <daniel@haxx.se>, et al.
+  *
+  * This software is licensed as described in the file COPYING, which
+  * you should have received as part of this distribution. The terms
+@@ -81,7 +81,7 @@
+ 
+ struct Cookie *Curl_cookie_getlist(struct CookieInfo *, const char *,
+                                    const char *, bool);
+-void Curl_cookie_freelist(struct Cookie *cookies, bool cookiestoo);
++void Curl_cookie_freelist(struct Cookie *cookies);
+ void Curl_cookie_clearall(struct CookieInfo *cookies);
+ void Curl_cookie_clearsess(struct CookieInfo *cookies);
+ 
+Index: curl-7.26.0/lib/http.c
+===================================================================
+--- curl-7.26.0.orig/lib/http.c	2016-11-01 14:52:55.977049528 +0100
++++ curl-7.26.0/lib/http.c	2016-11-01 14:52:55.973049638 +0100
+@@ -2235,7 +2235,7 @@
+         }
+         co = co->next; /* next cookie please */
+       }
+-      Curl_cookie_freelist(store, FALSE); /* free the cookie list */
++      Curl_cookie_freelist(store); /* free the cookie list */
+     }
+     if(addcookies && (CURLE_OK == result)) {
+       if(!count)

--- a/debian/patches/CVE-2016-8624.patch
+++ b/debian/patches/CVE-2016-8624.patch
@@ -1,0 +1,47 @@
+From 44ab42e55bbe329777ee05d50aea1ee059221652 Mon Sep 17 00:00:00 2001
+From: Daniel Stenberg <daniel@haxx.se>
+Date: Tue, 11 Oct 2016 00:48:35 +0200
+Subject: [PATCH] urlparse: accept '#' as end of host name
+
+'http://example.com#@127.0.0.1/x.txt' equals a request to example.com
+for the '/' document with the rest of the URL being a fragment.
+---
+ lib/url.c | 10 +++++-----
+ 1 file changed, 5 insertions(+), 5 deletions(-)
+
+Index: curl-7.26.0/lib/url.c
+===================================================================
+--- curl-7.26.0.orig/lib/url.c	2016-11-01 13:36:46.990264163 +0100
++++ curl-7.26.0/lib/url.c	2016-11-01 13:43:49.954671482 +0100
+@@ -3841,7 +3841,7 @@
+     path[0]=0;
+ 
+     if(2 > sscanf(data->change.url,
+-                   "%15[^\n:]://%[^\n/?]%[^\n]",
++                   "%15[^\n:]://%[^\n/?#]%[^\n]",
+                    protobuf,
+                    conn->host.name, path)) {
+ 
+@@ -3849,7 +3849,7 @@
+        * The URL was badly formatted, let's try the browser-style _without_
+        * protocol specified like 'http://'.
+        */
+-      rc = sscanf(data->change.url, "%[^\n/?]%[^\n]", conn->host.name, path);
++      rc = sscanf(data->change.url, "%[^\n/?#]%[^\n]", conn->host.name, path);
+       if(1 > rc) {
+         /*
+          * We couldn't even get this format.
+@@ -3930,10 +3930,10 @@
+   }
+ 
+   /* If the URL is malformatted (missing a '/' after hostname before path) we
+-   * insert a slash here. The only letter except '/' we accept to start a path
+-   * is '?'.
++   * insert a slash here. The only letters except '/' that can start a path is
++   * '?' and '#' - as controlled by the two sscanf() patterns above.
+    */
+-  if(path[0] == '?') {
++  if(path[0] != '/') {
+     /* We need this function to deal with overlapping memory areas. We know
+        that the memory area 'path' points to is 'urllen' bytes big and that
+        is bigger than the path. Use +1 to move the zero byte too. */

--- a/debian/patches/CVE-2016-8625.patch
+++ b/debian/patches/CVE-2016-8625.patch
@@ -1,0 +1,715 @@
+From 292422de6e2737cc3001b8dcb63cd0a4e08ad495 Mon Sep 17 00:00:00 2001
+From: Daniel Stenberg <daniel@haxx.se>
+Date: Wed, 12 Oct 2016 09:01:06 +0200
+Subject: [PATCH] idn: switch to libidn2 use and IDNA2008 support
+
+Reported-by: Christian Heimes
+---
+ CMakeLists.txt   | 13 ++------
+ configure.ac     | 76 +++++++++++++++++--------------------------
+ lib/curl_setup.h |  7 ++--
+ lib/easy.c       | 26 ---------------
+ lib/strerror.c   | 81 ++--------------------------------------------
+ lib/strerror.h   |  4 +--
+ lib/url.c        | 99 ++++++++++++--------------------------------------------
+ lib/version.c    | 14 ++++----
+ 8 files changed, 66 insertions(+), 254 deletions(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 6d19cb7..32eaea8 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -447,11 +447,11 @@ if(NOT CURL_DISABLE_LDAPS)
+   check_include_file_concat("ldap_ssl.h" HAVE_LDAP_SSL_H)
+   check_include_file_concat("ldapssl.h"  HAVE_LDAPSSL_H)
+ endif()
+ 
+ # Check for idn
+-check_library_exists_concat("idn" idna_to_ascii_lz HAVE_LIBIDN)
++check_library_exists_concat("idn2" idn2_lookup_ul HAVE_LIBIDN2)
+ 
+ # Check for symbol dlopen (same as HAVE_LIBDL)
+ check_library_exists("${CURL_LIBS}" dlopen "" HAVE_DLOPEN)
+ 
+ option(CURL_ZLIB "Set to ON to enable building cURL with zlib support." ON)
+@@ -616,11 +616,11 @@ check_include_file_concat("assert.h"         HAVE_ASSERT_H)
+ check_include_file_concat("crypto.h"         HAVE_CRYPTO_H)
+ check_include_file_concat("des.h"            HAVE_DES_H)
+ check_include_file_concat("err.h"            HAVE_ERR_H)
+ check_include_file_concat("errno.h"          HAVE_ERRNO_H)
+ check_include_file_concat("fcntl.h"          HAVE_FCNTL_H)
+-check_include_file_concat("idn-free.h"       HAVE_IDN_FREE_H)
++check_include_file_concat("idn2.h"           HAVE_IDN2_H)
+ check_include_file_concat("ifaddrs.h"        HAVE_IFADDRS_H)
+ check_include_file_concat("io.h"             HAVE_IO_H)
+ check_include_file_concat("krb.h"            HAVE_KRB_H)
+ check_include_file_concat("libgen.h"         HAVE_LIBGEN_H)
+ check_include_file_concat("limits.h"         HAVE_LIMITS_H)
+@@ -646,11 +646,10 @@ check_include_file_concat("string.h"         HAVE_STRING_H)
+ check_include_file_concat("strings.h"        HAVE_STRINGS_H)
+ check_include_file_concat("stropts.h"        HAVE_STROPTS_H)
+ check_include_file_concat("termio.h"         HAVE_TERMIO_H)
+ check_include_file_concat("termios.h"        HAVE_TERMIOS_H)
+ check_include_file_concat("time.h"           HAVE_TIME_H)
+-check_include_file_concat("tld.h"            HAVE_TLD_H)
+ check_include_file_concat("unistd.h"         HAVE_UNISTD_H)
+ check_include_file_concat("utime.h"          HAVE_UTIME_H)
+ check_include_file_concat("x509.h"           HAVE_X509_H)
+ 
+ check_include_file_concat("process.h"        HAVE_PROCESS_H)
+@@ -660,13 +659,10 @@ check_include_file_concat("malloc.h"         HAVE_MALLOC_H)
+ check_include_file_concat("memory.h"         HAVE_MEMORY_H)
+ check_include_file_concat("netinet/if_ether.h" HAVE_NETINET_IF_ETHER_H)
+ check_include_file_concat("stdint.h"        HAVE_STDINT_H)
+ check_include_file_concat("sockio.h"        HAVE_SOCKIO_H)
+ check_include_file_concat("sys/utsname.h"   HAVE_SYS_UTSNAME_H)
+-check_include_file_concat("idna.h"          HAVE_IDNA_H)
+-
+-
+ 
+ check_type_size(size_t  SIZEOF_SIZE_T)
+ check_type_size(ssize_t  SIZEOF_SSIZE_T)
+ check_type_size("long long"  SIZEOF_LONG_LONG)
+ check_type_size("long"  SIZEOF_LONG)
+@@ -809,13 +805,10 @@ check_symbol_exists(freeaddrinfo   "${CURL_INCLUDES}" HAVE_FREEADDRINFO)
+ check_symbol_exists(freeifaddrs    "${CURL_INCLUDES}" HAVE_FREEIFADDRS)
+ check_symbol_exists(pipe           "${CURL_INCLUDES}" HAVE_PIPE)
+ check_symbol_exists(ftruncate      "${CURL_INCLUDES}" HAVE_FTRUNCATE)
+ check_symbol_exists(getprotobyname "${CURL_INCLUDES}" HAVE_GETPROTOBYNAME)
+ check_symbol_exists(getrlimit      "${CURL_INCLUDES}" HAVE_GETRLIMIT)
+-check_symbol_exists(idn_free       "${CURL_INCLUDES}" HAVE_IDN_FREE)
+-check_symbol_exists(idna_strerror  "${CURL_INCLUDES}" HAVE_IDNA_STRERROR)
+-check_symbol_exists(tld_strerror   "${CURL_INCLUDES}" HAVE_TLD_STRERROR)
+ check_symbol_exists(setlocale      "${CURL_INCLUDES}" HAVE_SETLOCALE)
+ check_symbol_exists(setrlimit      "${CURL_INCLUDES}" HAVE_SETRLIMIT)
+ check_symbol_exists(fcntl          "${CURL_INCLUDES}" HAVE_FCNTL)
+ check_symbol_exists(ioctl          "${CURL_INCLUDES}" HAVE_IOCTL)
+ check_symbol_exists(setsockopt     "${CURL_INCLUDES}" HAVE_SETSOCKOPT)
+@@ -1076,11 +1069,11 @@ _add_if("WinSSL"        SSL_ENABLED AND USE_WINDOWS_SSPI)
+ _add_if("OpenSSL"       SSL_ENABLED AND USE_OPENSSL)
+ _add_if("IPv6"          ENABLE_IPV6)
+ _add_if("unix-sockets"  USE_UNIX_SOCKETS)
+ _add_if("libz"          HAVE_LIBZ)
+ _add_if("AsynchDNS"     USE_ARES OR USE_THREADS_POSIX OR USE_THREADS_WIN32)
+-_add_if("IDN"           HAVE_LIBIDN)
++_add_if("IDN"           HAVE_LIBIDN2)
+ _add_if("Largefile"     (CURL_SIZEOF_CURL_OFF_T GREATER 4) AND
+                         ((SIZEOF_OFF_T GREATER 4) OR USE_WIN32_LARGE_FILES))
+ # TODO SSP1 (WinSSL) check is missing
+ _add_if("SSPI"          USE_WINDOWS_SSPI)
+ _add_if("GSS-API"       HAVE_GSSAPI)
+diff --git a/configure.ac b/configure.ac
+index 1f01467..49499a8 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -155,11 +155,11 @@ dnl initialize all the info variables
+     curl_gss_msg="no      (--with-gssapi)"
+ curl_tls_srp_msg="no      (--enable-tls-srp)"
+     curl_res_msg="default (--enable-ares / --enable-threaded-resolver)"
+    curl_ipv6_msg="no      (--enable-ipv6)"
+ curl_unix_sockets_msg="no      (--enable-unix-sockets)"
+-    curl_idn_msg="no      (--with-{libidn,winidn})"
++    curl_idn_msg="no      (--with-{libidn2,winidn})"
+  curl_manual_msg="no      (--enable-manual)"
+ curl_libcurl_msg="enabled (--disable-libcurl-option)"
+ curl_verbose_msg="enabled (--disable-verbose)"
+    curl_sspi_msg="no      (--enable-sspi)"
+    curl_ldap_msg="no      (--enable-ldap / --with-ldap-lib / --with-lber-lib)"
+@@ -2826,36 +2826,36 @@ fi
+ 
+ dnl **********************************************************************
+ dnl Check for the presence of IDN libraries and headers
+ dnl **********************************************************************
+ 
+-AC_MSG_CHECKING([whether to build with libidn])
++AC_MSG_CHECKING([whether to build with libidn2])
+ OPT_IDN="default"
+ AC_ARG_WITH(libidn,
+-AC_HELP_STRING([--with-libidn=PATH],[Enable libidn usage])
+-AC_HELP_STRING([--without-libidn],[Disable libidn usage]),
++AC_HELP_STRING([--with-libidn2=PATH],[Enable libidn2 usage])
++AC_HELP_STRING([--without-libidn2],[Disable libidn2 usage]),
+   [OPT_IDN=$withval])
+ case "$OPT_IDN" in
+   no)
+-    dnl --without-libidn option used
++    dnl --without-libidn2 option used
+     want_idn="no"
+     AC_MSG_RESULT([no])
+     ;;
+   default)
+     dnl configure option not specified
+     want_idn="yes"
+     want_idn_path="default"
+     AC_MSG_RESULT([(assumed) yes])
+     ;;
+   yes)
+-    dnl --with-libidn option used without path
++    dnl --with-libidn2 option used without path
+     want_idn="yes"
+     want_idn_path="default"
+     AC_MSG_RESULT([yes])
+     ;;
+   *)
+-    dnl --with-libidn option used with path
++    dnl --with-libidn2 option used with path
+     want_idn="yes"
+     want_idn_path="$withval"
+     AC_MSG_RESULT([yes ($withval)])
+     ;;
+ esac
+@@ -2868,37 +2868,37 @@ if test "$want_idn" = "yes"; then
+   PKGCONFIG="no"
+   #
+   if test "$want_idn_path" != "default"; then
+     dnl path has been specified
+     IDN_PCDIR="$want_idn_path/lib$libsuff/pkgconfig"
+-    CURL_CHECK_PKGCONFIG(libidn, [$IDN_PCDIR])
++    CURL_CHECK_PKGCONFIG(libidn2, [$IDN_PCDIR])
+     if test "$PKGCONFIG" != "no"; then
+       IDN_LIBS=`CURL_EXPORT_PCDIR([$IDN_PCDIR]) dnl
+-        $PKGCONFIG --libs-only-l libidn 2>/dev/null`
++        $PKGCONFIG --libs-only-l libidn2 2>/dev/null`
+       IDN_LDFLAGS=`CURL_EXPORT_PCDIR([$IDN_PCDIR]) dnl
+-        $PKGCONFIG --libs-only-L libidn 2>/dev/null`
++        $PKGCONFIG --libs-only-L libidn2 2>/dev/null`
+       IDN_CPPFLAGS=`CURL_EXPORT_PCDIR([$IDN_PCDIR]) dnl
+-        $PKGCONFIG --cflags-only-I libidn 2>/dev/null`
++        $PKGCONFIG --cflags-only-I libidn2 2>/dev/null`
+       IDN_DIR=`echo $IDN_LDFLAGS | $SED -e 's/-L//'`
+     else
+       dnl pkg-config not available or provides no info
+-      IDN_LIBS="-lidn"
++      IDN_LIBS="-lidn2"
+       IDN_LDFLAGS="-L$want_idn_path/lib$libsuff"
+       IDN_CPPFLAGS="-I$want_idn_path/include"
+       IDN_DIR="$want_idn_path/lib$libsuff"
+     fi
+   else
+     dnl path not specified
+-    CURL_CHECK_PKGCONFIG(libidn)
++    CURL_CHECK_PKGCONFIG(libidn2)
+     if test "$PKGCONFIG" != "no"; then
+-      IDN_LIBS=`$PKGCONFIG --libs-only-l libidn 2>/dev/null`
+-      IDN_LDFLAGS=`$PKGCONFIG --libs-only-L libidn 2>/dev/null`
+-      IDN_CPPFLAGS=`$PKGCONFIG --cflags-only-I libidn 2>/dev/null`
++      IDN_LIBS=`$PKGCONFIG --libs-only-l libidn2 2>/dev/null`
++      IDN_LDFLAGS=`$PKGCONFIG --libs-only-L libidn2 2>/dev/null`
++      IDN_CPPFLAGS=`$PKGCONFIG --cflags-only-I libidn2 2>/dev/null`
+       IDN_DIR=`echo $IDN_LDFLAGS | $SED -e 's/-L//'`
+     else
+       dnl pkg-config not available or provides no info
+-      IDN_LIBS="-lidn"
++      IDN_LIBS="-lidn2"
+     fi
+   fi
+   #
+   if test "$PKGCONFIG" != "no"; then
+     AC_MSG_NOTICE([pkg-config: IDN_LIBS: "$IDN_LIBS"])
+@@ -2914,51 +2914,33 @@ if test "$want_idn" = "yes"; then
+   #
+   CPPFLAGS="$IDN_CPPFLAGS $CPPFLAGS"
+   LDFLAGS="$IDN_LDFLAGS $LDFLAGS"
+   LIBS="$IDN_LIBS $LIBS"
+   #
+-  AC_MSG_CHECKING([if idna_to_ascii_4i can be linked])
++  AC_MSG_CHECKING([if idn2_lookup_ul can be linked])
+   AC_LINK_IFELSE([
+-    AC_LANG_FUNC_LINK_TRY([idna_to_ascii_4i])
++    AC_LANG_FUNC_LINK_TRY([idn2_lookup_ul])
+   ],[
+     AC_MSG_RESULT([yes])
+     tst_links_libidn="yes"
+   ],[
+     AC_MSG_RESULT([no])
+     tst_links_libidn="no"
+   ])
+-  if test "$tst_links_libidn" = "no"; then
+-    AC_MSG_CHECKING([if idna_to_ascii_lz can be linked])
+-    AC_LINK_IFELSE([
+-      AC_LANG_FUNC_LINK_TRY([idna_to_ascii_lz])
+-    ],[
+-      AC_MSG_RESULT([yes])
+-      tst_links_libidn="yes"
+-    ],[
+-      AC_MSG_RESULT([no])
+-      tst_links_libidn="no"
+-    ])
+-  fi
+   #
++  AC_CHECK_HEADERS( idn2.h )
++
+   if test "$tst_links_libidn" = "yes"; then
+-    AC_DEFINE(HAVE_LIBIDN, 1, [Define to 1 if you have the `idn' library (-lidn).])
++    AC_DEFINE(HAVE_LIBIDN2, 1, [Define to 1 if you have the `idn2' library (-lidn2).])
+     dnl different versions of libidn have different setups of these:
+-    AC_CHECK_FUNCS( idn_free idna_strerror tld_strerror )
+-    AC_CHECK_HEADERS( idn-free.h tld.h )
+-    if test "x$ac_cv_header_tld_h" = "xyes"; then
+-      AC_SUBST([IDN_ENABLED], [1])
+-      curl_idn_msg="enabled"
+-      if test -n "$IDN_DIR" -a "x$cross_compiling" != "xyes"; then
+-        LD_LIBRARY_PATH="$LD_LIBRARY_PATH:$IDN_DIR"
+-        export LD_LIBRARY_PATH
+-        AC_MSG_NOTICE([Added $IDN_DIR to LD_LIBRARY_PATH])
+-      fi
+-    else
+-      AC_MSG_WARN([Libraries for IDN support too old: IDN disabled])
+-      CPPFLAGS="$clean_CPPFLAGS"
+-      LDFLAGS="$clean_LDFLAGS"
+-      LIBS="$clean_LIBS"
++
++    AC_SUBST([IDN_ENABLED], [1])
++    curl_idn_msg="enabled (libidn2)"
++    if test -n "$IDN_DIR" -a "x$cross_compiling" != "xyes"; then
++      LD_LIBRARY_PATH="$LD_LIBRARY_PATH:$IDN_DIR"
++      export LD_LIBRARY_PATH
++      AC_MSG_NOTICE([Added $IDN_DIR to LD_LIBRARY_PATH])
+     fi
+   else
+     AC_MSG_WARN([Cannot find libraries for IDN support: IDN disabled])
+     CPPFLAGS="$clean_CPPFLAGS"
+     LDFLAGS="$clean_LDFLAGS"
+diff --git a/lib/curl_setup.h b/lib/curl_setup.h
+index 5d82e33..9619a1e 100644
+--- a/lib/curl_setup.h
++++ b/lib/curl_setup.h
+@@ -597,14 +597,13 @@ int netware_init(void);
+ #include <sys/bsdskt.h>
+ #include <sys/timeval.h>
+ #endif
+ #endif
+ 
+-#if defined(HAVE_LIBIDN) && defined(HAVE_TLD_H)
+-/* The lib was present and the tld.h header (which is missing in libidn 0.3.X
+-   but we only work with libidn 0.4.1 or later) */
+-#define USE_LIBIDN
++#if defined(HAVE_LIBIDN2) && defined(HAVE_IDN2_H)
++/* The lib and header are present */
++#define USE_LIBIDN2
+ #endif
+ 
+ #ifndef SIZEOF_TIME_T
+ /* assume default size of time_t to be 32 bit */
+ #define SIZEOF_TIME_T 4
+diff --git a/lib/easy.c b/lib/easy.c
+index 08adf6d..b28e4f8 100644
+--- a/lib/easy.c
++++ b/lib/easy.c
+@@ -142,32 +142,10 @@ static CURLcode win32_init(void)
+ #endif
+ 
+   return CURLE_OK;
+ }
+ 
+-#ifdef USE_LIBIDN
+-/*
+- * Initialise use of IDNA library.
+- * It falls back to ASCII if $CHARSET isn't defined. This doesn't work for
+- * idna_to_ascii_lz().
+- */
+-static void idna_init (void)
+-{
+-#ifdef WIN32
+-  char buf[60];
+-  UINT cp = GetACP();
+-
+-  if(!getenv("CHARSET") && cp > 0) {
+-    snprintf(buf, sizeof(buf), "CHARSET=cp%u", cp);
+-    putenv(buf);
+-  }
+-#else
+-  /* to do? */
+-#endif
+-}
+-#endif  /* USE_LIBIDN */
+-
+ /* true globals -- for curl_global_init() and curl_global_cleanup() */
+ static unsigned int  initialized;
+ static long          init_flags;
+ 
+ /*
+@@ -260,14 +238,10 @@ static CURLcode global_init(long flags, bool memoryfuncs)
+   if(netware_init()) {
+     DEBUGF(fprintf(stderr, "Warning: LONG namespace not available\n"));
+   }
+ #endif
+ 
+-#ifdef USE_LIBIDN
+-  idna_init();
+-#endif
+-
+   if(Curl_resolver_global_init()) {
+     DEBUGF(fprintf(stderr, "Error: resolver_global_init failed\n"));
+     return CURLE_FAILED_INIT;
+   }
+ 
+diff --git a/lib/strerror.c b/lib/strerror.c
+index 9c58e6b..7f1f1de 100644
+--- a/lib/strerror.c
++++ b/lib/strerror.c
+@@ -33,12 +33,12 @@
+ #  endif
+ #endif
+ 
+ #include <curl/curl.h>
+ 
+-#ifdef USE_LIBIDN
+-#include <idna.h>
++#ifdef USE_LIBIDN2
++#include <idn2.h>
+ #endif
+ 
+ #ifdef USE_WINDOWS_SSPI
+ #include "curl_sspi.h"
+ #endif
+@@ -724,87 +724,10 @@ const char *Curl_strerror(struct connectdata *conn, int err)
+     SET_ERRNO(old_errno);
+ 
+   return buf;
+ }
+ 
+-#ifdef USE_LIBIDN
+-/*
+- * Return error-string for libidn status as returned from idna_to_ascii_lz().
+- */
+-const char *Curl_idn_strerror (struct connectdata *conn, int err)
+-{
+-#ifdef HAVE_IDNA_STRERROR
+-  (void)conn;
+-  return idna_strerror((Idna_rc) err);
+-#else
+-  const char *str;
+-  char *buf;
+-  size_t max;
+-
+-  DEBUGASSERT(conn);
+-
+-  buf = conn->syserr_buf;
+-  max = sizeof(conn->syserr_buf)-1;
+-  *buf = '\0';
+-
+-#ifndef CURL_DISABLE_VERBOSE_STRINGS
+-  switch ((Idna_rc)err) {
+-    case IDNA_SUCCESS:
+-      str = "No error";
+-      break;
+-    case IDNA_STRINGPREP_ERROR:
+-      str = "Error in string preparation";
+-      break;
+-    case IDNA_PUNYCODE_ERROR:
+-      str = "Error in Punycode operation";
+-      break;
+-    case IDNA_CONTAINS_NON_LDH:
+-      str = "Illegal ASCII characters";
+-      break;
+-    case IDNA_CONTAINS_MINUS:
+-      str = "Contains minus";
+-      break;
+-    case IDNA_INVALID_LENGTH:
+-      str = "Invalid output length";
+-      break;
+-    case IDNA_NO_ACE_PREFIX:
+-      str = "No ACE prefix (\"xn--\")";
+-      break;
+-    case IDNA_ROUNDTRIP_VERIFY_ERROR:
+-      str = "Round trip verify error";
+-      break;
+-    case IDNA_CONTAINS_ACE_PREFIX:
+-      str = "Already have ACE prefix (\"xn--\")";
+-      break;
+-    case IDNA_ICONV_ERROR:
+-      str = "Locale conversion failed";
+-      break;
+-    case IDNA_MALLOC_ERROR:
+-      str = "Allocation failed";
+-      break;
+-    case IDNA_DLOPEN_ERROR:
+-      str = "dlopen() error";
+-      break;
+-    default:
+-      snprintf(buf, max, "error %d", err);
+-      str = NULL;
+-      break;
+-  }
+-#else
+-  if((Idna_rc)err == IDNA_SUCCESS)
+-    str = "No error";
+-  else
+-    str = "Error";
+-#endif
+-  if(str)
+-    strncpy(buf, str, max);
+-  buf[max] = '\0';
+-  return (buf);
+-#endif
+-}
+-#endif  /* USE_LIBIDN */
+-
+ #ifdef USE_WINDOWS_SSPI
+ const char *Curl_sspi_strerror (struct connectdata *conn, int err)
+ {
+ #ifndef CURL_DISABLE_VERBOSE_STRINGS
+   char txtbuf[80];
+diff --git a/lib/strerror.h b/lib/strerror.h
+index ae8c96b..627273e 100644
+--- a/lib/strerror.h
++++ b/lib/strerror.h
+@@ -5,11 +5,11 @@
+  *  Project                     ___| | | |  _ \| |
+  *                             / __| | | | |_) | |
+  *                            | (__| |_| |  _ <| |___
+  *                             \___|\___/|_| \_\_____|
+  *
+- * Copyright (C) 1998 - 2012, Daniel Stenberg, <daniel@haxx.se>, et al.
++ * Copyright (C) 1998 - 2016, Daniel Stenberg, <daniel@haxx.se>, et al.
+  *
+  * This software is licensed as described in the file COPYING, which
+  * you should have received as part of this distribution. The terms
+  * are also available at https://curl.haxx.se/docs/copyright.html.
+  *
+@@ -24,11 +24,11 @@
+ 
+ #include "urldata.h"
+ 
+ const char *Curl_strerror (struct connectdata *conn, int err);
+ 
+-#ifdef USE_LIBIDN
++#ifdef USE_LIBIDN2
+ const char *Curl_idn_strerror (struct connectdata *conn, int err);
+ #endif
+ 
+ #ifdef USE_WINDOWS_SSPI
+ const char *Curl_sspi_strerror (struct connectdata *conn, int err);
+diff --git a/lib/url.c b/lib/url.c
+index 74e9bf5..8597064 100644
+--- a/lib/url.c
++++ b/lib/url.c
+@@ -57,28 +57,19 @@
+ 
+ #ifdef HAVE_LIMITS_H
+ #include <limits.h>
+ #endif
+ 
+-#ifdef USE_LIBIDN
+-#include <idna.h>
+-#include <tld.h>
+-#include <stringprep.h>
+-#ifdef HAVE_IDN_FREE_H
+-#include <idn-free.h>
+-#else
+-/* prototype from idn-free.h, not provided by libidn 0.4.5's make install! */
+-void idn_free (void *ptr);
+-#endif
+-#ifndef HAVE_IDN_FREE
+-/* if idn_free() was not found in this version of libidn use free() instead */
+-#define idn_free(x) (free)(x)
+-#endif
++#ifdef USE_LIBIDN2
++#include <idn2.h>
++
+ #elif defined(USE_WIN32_IDN)
+ /* prototype for curl_win32_idn_to_ascii() */
+ bool curl_win32_idn_to_ascii(const char *in, char **out);
+-#endif  /* USE_LIBIDN */
++#endif  /* USE_LIBIDN2 */
++
++#include <idn2.h>
+ 
+ #include "urldata.h"
+ #include "netrc.h"
+ 
+ #include "formdata.h"
+@@ -3766,62 +3757,19 @@ static bool is_ASCII_name(const char *hostname)
+       return FALSE;
+   }
+   return TRUE;
+ }
+ 
+-#ifdef USE_LIBIDN
+-/*
+- * Check if characters in hostname is allowed in Top Level Domain.
+- */
+-static bool tld_check_name(struct Curl_easy *data,
+-                           const char *ace_hostname)
+-{
+-  size_t err_pos;
+-  char *uc_name = NULL;
+-  int rc;
+-#ifndef CURL_DISABLE_VERBOSE_STRINGS
+-  const char *tld_errmsg = "<no msg>";
+-#else
+-  (void)data;
+-#endif
+-
+-  /* Convert (and downcase) ACE-name back into locale's character set */
+-  rc = idna_to_unicode_lzlz(ace_hostname, &uc_name, 0);
+-  if(rc != IDNA_SUCCESS)
+-    return FALSE;
+-
+-  /* Warning: err_pos receives "the decoded character offset rather than the
+-     byte position in the string." And as of libidn 1.32 that character offset
+-     is for UTF-8, even if the passed in string is another locale. */
+-  rc = tld_check_lz(uc_name, &err_pos, NULL);
+-#ifndef CURL_DISABLE_VERBOSE_STRINGS
+-#ifdef HAVE_TLD_STRERROR
+-  if(rc != TLD_SUCCESS)
+-    tld_errmsg = tld_strerror((Tld_rc)rc);
+-#endif
+-  if(rc != TLD_SUCCESS)
+-    infof(data, "WARNING: TLD check for %s failed; %s\n",
+-          uc_name, tld_errmsg);
+-#endif /* CURL_DISABLE_VERBOSE_STRINGS */
+-  if(uc_name)
+-     idn_free(uc_name);
+-  if(rc != TLD_SUCCESS)
+-    return FALSE;
+-
+-  return TRUE;
+-}
+-#endif
+-
+ /*
+  * Perform any necessary IDN conversion of hostname
+  */
+-static void fix_hostname(struct Curl_easy *data,
+-                         struct connectdata *conn, struct hostname *host)
++static void fix_hostname(struct connectdata *conn, struct hostname *host)
+ {
+   size_t len;
++  struct Curl_easy *data = conn->data;
+ 
+-#ifndef USE_LIBIDN
++#ifndef USE_LIBIDN2
+   (void)data;
+   (void)conn;
+ #elif defined(CURL_DISABLE_VERBOSE_STRINGS)
+   (void)conn;
+ #endif
+@@ -3835,29 +3783,22 @@ static void fix_hostname(struct Curl_easy *data,
+        there's no use for it */
+     host->name[len-1]=0;
+ 
+   /* Check name for non-ASCII and convert hostname to ACE form if we can */
+   if(!is_ASCII_name(host->name)) {
+-#ifdef USE_LIBIDN
+-    if(stringprep_check_version(LIBIDN_REQUIRED_VERSION)) {
++#ifdef USE_LIBIDN2
++    if(idn2_check_version(IDN2_VERSION)) {
+       char *ace_hostname = NULL;
+-
+-      int rc = idna_to_ascii_lz(host->name, &ace_hostname, 0);
+-      infof(data, "Input domain encoded as `%s'\n",
+-            stringprep_locale_charset());
+-      if(rc == IDNA_SUCCESS) {
+-        /* tld_check_name() displays a warning if the host name contains
+-           "illegal" characters for this TLD */
+-        (void)tld_check_name(data, ace_hostname);
+-
+-        host->encalloc = ace_hostname;
++      int rc = idn2_lookup_ul((const char *)host->name, &ace_hostname, 0);
++      if(rc == IDN2_OK) {
++        host->encalloc = (char *)ace_hostname;
+         /* change the name pointer to point to the encoded hostname */
+         host->name = host->encalloc;
+       }
+       else
+         infof(data, "Failed to convert %s to ACE; %s\n", host->name,
+-              Curl_idn_strerror(conn, rc));
++              idn2_strerror(rc));
+     }
+ #elif defined(USE_WIN32_IDN)
+     char *ace_hostname = NULL;
+ 
+     if(curl_win32_idn_to_ascii(host->name, &ace_hostname)) {
+@@ -3876,13 +3817,13 @@ static void fix_hostname(struct Curl_easy *data,
+ /*
+  * Frees data allocated by fix_hostname()
+  */
+ static void free_fixed_hostname(struct hostname *host)
+ {
+-#if defined(USE_LIBIDN)
++#if defined(USE_LIBIDN2)
+   if(host->encalloc) {
+-    idn_free(host->encalloc); /* must be freed with idn_free() since this was
++    idn2_free(host->encalloc); /* must be freed with idn2_free() since this was
+                                  allocated by libidn */
+     host->encalloc = NULL;
+   }
+ #elif defined(USE_WIN32_IDN)
+   free(host->encalloc); /* must be freed withidn_free() since this was
+@@ -6041,15 +5982,15 @@ static CURLcode create_conn(struct Curl_easy *data,
+     goto out;
+ 
+   /*************************************************************
+    * IDN-fix the hostnames
+    *************************************************************/
+-  fix_hostname(data, conn, &conn->host);
++  fix_hostname(conn, &conn->host);
+   if(conn->bits.conn_to_host)
+-    fix_hostname(data, conn, &conn->conn_to_host);
++    fix_hostname(conn, &conn->conn_to_host);
+   if(conn->proxy.name && *conn->proxy.name)
+-    fix_hostname(data, conn, &conn->proxy);
++    fix_hostname(conn, &conn->proxy);
+ 
+   /*************************************************************
+    * Check whether the host and the "connect to host" are equal.
+    * Do this after the hostnames have been IDN-fixed .
+    *************************************************************/
+diff --git a/lib/version.c b/lib/version.c
+index 1292445..a434a62 100644
+--- a/lib/version.c
++++ b/lib/version.c
+@@ -34,12 +34,12 @@
+ #    define CARES_STATICLIB
+ #  endif
+ #  include <ares.h>
+ #endif
+ 
+-#ifdef USE_LIBIDN
+-#include <stringprep.h>
++#ifdef USE_LIBIDN2
++#include <idn2.h>
+ #endif
+ 
+ #ifdef USE_LIBPSL
+ #include <libpsl.h>
+ #endif
+@@ -109,13 +109,13 @@ char *curl_version(void)
+   /* this function is only present in c-ares, not in the original ares */
+   len = snprintf(ptr, left, " c-ares/%s", ares_version(NULL));
+   left -= len;
+   ptr += len;
+ #endif
+-#ifdef USE_LIBIDN
+-  if(stringprep_check_version(LIBIDN_REQUIRED_VERSION)) {
+-    len = snprintf(ptr, left, " libidn/%s", stringprep_check_version(NULL));
++#ifdef USE_LIBIDN2
++  if(idn2_check_version(IDN2_VERSION)) {
++    len = snprintf(ptr, left, " libidn2/%s", idn2_check_version(NULL));
+     left -= len;
+     ptr += len;
+   }
+ #endif
+ #ifdef USE_LIBPSL
+@@ -363,14 +363,14 @@ curl_version_info_data *curl_version_info(CURLversion stamp)
+     int aresnum;
+     version_info.ares = ares_version(&aresnum);
+     version_info.ares_num = aresnum;
+   }
+ #endif
+-#ifdef USE_LIBIDN
++#ifdef USE_LIBIDN2
+   /* This returns a version string if we use the given version or later,
+      otherwise it returns NULL */
+-  version_info.libidn = stringprep_check_version(LIBIDN_REQUIRED_VERSION);
++  version_info.libidn = idn2_check_version(IDN2_VERSION);
+   if(version_info.libidn)
+     version_info.features |= CURL_VERSION_IDN;
+ #elif defined(USE_WIN32_IDN)
+   version_info.features |= CURL_VERSION_IDN;
+ #endif
+-- 
+2.9.3
+

--- a/debian/patches/CVE-2016-9586.patch
+++ b/debian/patches/CVE-2016-9586.patch
@@ -1,0 +1,247 @@
+From 5b988c081e6224b2202f114a01742f76dea27c42 Mon Sep 17 00:00:00 2001
+From: Daniel Stenberg <daniel@haxx.se>
+Date: Tue, 8 Nov 2016 15:32:37 +0100
+Subject: [PATCH] printf: fix floating point buffer overflow issues
+
+... and add a bunch of floating point printf tests
+
+Back-ported to curl 7.26 by Balint Reczey <balint@balintreczey.hu>
+
+Conflicts:
+	tests/data/test557
+	tests/libtest/lib557.c
+---
+ lib/mprintf.c          |  20 ++++++-
+ tests/data/test557     |   1 +
+ tests/libtest/lib557.c | 140 +++++++++++++++++++++++++++++++++++++++++++++++++
+ 3 files changed, 159 insertions(+), 2 deletions(-)
+
+--- a/lib/mprintf.c
++++ b/lib/mprintf.c
+@@ -84,7 +84,8 @@
+ #  define mp_uintmax_t unsigned long
+ #endif
+ 
+-#define BUFFSIZE 256 /* buffer for long-to-str and float-to-str calcs */
++#define BUFFSIZE 326 /* buffer for long-to-str and float-to-str calcs, should
++                        fit negative DBL_MAX (317 letters) */
+ #define MAX_PARAMETERS 128 /* lame static limit */
+ 
+ #ifdef __AMIGA__
+@@ -947,12 +948,25 @@
+         fptr=&formatbuf[strlen(formatbuf)];
+ 
+         if(width >= 0) {
++          if(width >= (long)sizeof(work))
++            width = sizeof(work)-1;
+           /* RECURSIVE USAGE */
+           len = curl_msnprintf(fptr, left, "%ld", width);
+           fptr += len;
+           left -= len;
+         }
+         if(prec >= 0) {
++          /* for each digit in the integer part, we can have one less
++             precision */
++          size_t maxprec = sizeof(work) - 2;
++          double val = p->data.dnum;
++          while(val >= 10.0) {
++            val /= 10;
++            maxprec--;
++          }
++
++          if(prec > (long)maxprec)
++            prec = maxprec-1;
+           /* RECURSIVE USAGE */
+           len = curl_msnprintf(fptr, left, ".%ld", prec);
+           fptr += len;
+@@ -972,7 +986,9 @@
+         /* NOTE NOTE NOTE!! Not all sprintf() implementations returns number
+            of output characters */
+         (sprintf)(work, formatbuf, p->data.dnum);
+-
++#ifdef CURLDEBUG
++        assert(strlen(work) <= sizeof(work));
++#endif
+         for(fptr=work; *fptr; fptr++)
+           OUTCHAR(*fptr);
+       }
+--- a/tests/data/test557
++++ b/tests/data/test557
+@@ -33,6 +33,7 @@
+ All curl_mprintf() unsigned long tests OK!
+ All curl_mprintf() signed long tests OK!
+ All curl_mprintf() curl_off_t tests OK!
++All float strings tests OK!
+ </stdout>
+ </verify>
+ 
+--- a/tests/libtest/lib557.c
++++ b/tests/libtest/lib557.c
+@@ -1374,6 +1374,158 @@
+   return failed;
+ }
+ 
++static int _string_check(int linenumber, char *buf, const char *buf2)
++{
++  if(strcmp(buf, buf2)) {
++    /* they shouldn't differ */
++    printf("sprintf line %d failed:\nwe      '%s'\nsystem: '%s'\n",
++           linenumber, buf, buf2);
++    return 1;
++  }
++  return 0;
++}
++#define string_check(x,y) _string_check(__LINE__, x, y)
++
++static int _strlen_check(int linenumber, char *buf, size_t len)
++{
++  size_t buflen = strlen(buf);
++  if(len != buflen) {
++    /* they shouldn't differ */
++    printf("sprintf strlen:%d failed:\nwe '%d'\nsystem: '%d'\n",
++           linenumber, buflen, len);
++    return 1;
++  }
++  return 0;
++}
++
++#define strlen_check(x,y) _strlen_check(__LINE__, x, y)
++
++/* DBL_MAX value from Linux */
++#define MAXIMIZE -179769313486231570814527423731704356798070567525844996598917476803157260780028538760589558632766878171540458953514382464234321326889464182768467546703537516986049910576551282076245490090389328944075868508455133942304583236903222948165808559332123348274797826204144723168738177180919299881250404026184124858368.000000
++
++static int test_float_formatting(void)
++{
++  int errors = 0;
++  char buf[512]; /* larger than max float size */
++  curl_msnprintf(buf, sizeof(buf), "%f", 9.0);
++  errors += string_check(buf, "9.000000");
++
++  curl_msnprintf(buf, sizeof(buf), "%.1f", 9.1);
++  errors += string_check(buf, "9.1");
++
++  curl_msnprintf(buf, sizeof(buf), "%.2f", 9.1);
++  errors += string_check(buf, "9.10");
++
++  curl_msnprintf(buf, sizeof(buf), "%.0f", 9.1);
++  errors += string_check(buf, "9");
++
++  curl_msnprintf(buf, sizeof(buf), "%0f", 9.1);
++  errors += string_check(buf, "9.100000");
++
++  curl_msnprintf(buf, sizeof(buf), "%10f", 9.1);
++  errors += string_check(buf, "  9.100000");
++
++  curl_msnprintf(buf, sizeof(buf), "%10.3f", 9.1);
++  errors += string_check(buf, "     9.100");
++
++  curl_msnprintf(buf, sizeof(buf), "%-10.3f", 9.1);
++  errors += string_check(buf, "9.100     ");
++
++  curl_msnprintf(buf, sizeof(buf), "%-10.3f", 9.123456);
++  errors += string_check(buf, "9.123     ");
++
++  curl_msnprintf(buf, sizeof(buf), "%.-2f", 9.1);
++  errors += string_check(buf, "9.100000");
++
++  curl_msnprintf(buf, sizeof(buf), "%*f", 10, 9.1);
++  errors += string_check(buf, "  9.100000");
++
++  curl_msnprintf(buf, sizeof(buf), "%*f", 3, 9.1);
++  errors += string_check(buf, "9.100000");
++
++  curl_msnprintf(buf, sizeof(buf), "%*f", 6, 9.2987654);
++  errors += string_check(buf, "9.298765");
++
++  curl_msnprintf(buf, sizeof(buf), "%*f", 6, 9.298765);
++  errors += string_check(buf, "9.298765");
++
++  curl_msnprintf(buf, sizeof(buf), "%*f", 6, 9.29876);
++  errors += string_check(buf, "9.298760");
++
++  curl_msnprintf(buf, sizeof(buf), "%.*f", 6, 9.2987654);
++  // buggy in 7.26
++  // errors += string_check(buf, "9.298765");
++  errors += string_check(buf, "9.3");
++  curl_msnprintf(buf, sizeof(buf), "%.*f", 5, 9.2987654);
++  // buggy in 7.26
++  // errors += string_check(buf, "9.29877");
++  errors += string_check(buf, "9.3");
++  curl_msnprintf(buf, sizeof(buf), "%.*f", 4, 9.2987654);
++  // buggy in 7.26
++  // errors += string_check(buf, "9.2988");
++  errors += string_check(buf, "9.3");
++  curl_msnprintf(buf, sizeof(buf), "%.*f", 3, 9.2987654);
++  // buggy in 7.26
++  // errors += string_check(buf, "9.299");
++  errors += string_check(buf, "9.3");
++  curl_msnprintf(buf, sizeof(buf), "%.*f", 2, 9.2987654);
++  // buggy in 7.26
++  // errors += string_check(buf, "9.30");
++  errors += string_check(buf, "9.3");
++  curl_msnprintf(buf, sizeof(buf), "%.*f", 1, 9.2987654);
++  errors += string_check(buf, "9.3");
++  curl_msnprintf(buf, sizeof(buf), "%.*f", 0, 9.2987654);
++  // buggy in 7.26
++  //errors += string_check(buf, "9");
++  errors += string_check(buf, "9.3");
++
++  /* very large precisions easily turn into system specific outputs so we only
++     check the output buffer length here as we know the internal limit */
++
++  curl_msnprintf(buf, sizeof(buf), "%.*f", (1<<30), 9.2987654);
++  // buggy in 7.26
++  // errors += strlen_check(buf, 325);
++  errors += strlen_check(buf, 3);
++
++  curl_msnprintf(buf, sizeof(buf), "%10000.10000f", 9.2987654);
++  errors += strlen_check(buf, 325);
++
++  curl_msnprintf(buf, sizeof(buf), "%240.10000f",
++                 123456789123456789123456789.2987654);
++  errors += strlen_check(buf, 325);
++
++  /* 1<<31 turns negative (-2147483648) when used signed */
++  curl_msnprintf(buf, sizeof(buf), "%*f", (1<<31), 9.1);
++  errors += string_check(buf, "9.100000");
++
++  /* curl_msnprintf() limits a single float output to 325 bytes maximum
++     width */
++  curl_msnprintf(buf, sizeof(buf), "%*f", (1<<30), 9.1);
++  errors += string_check(buf, "                                                                                                                                                                                                                                                                                                                             9.100000");
++  curl_msnprintf(buf, sizeof(buf), "%100000f", 9.1);
++  errors += string_check(buf, "                                                                                                                                                                                                                                                                                                                             9.100000");
++
++  curl_msnprintf(buf, sizeof(buf), "%f", MAXIMIZE);
++  errors += strlen_check(buf, 317);
++
++  curl_msnprintf(buf, 2, "%f", MAXIMIZE);
++  errors += strlen_check(buf, 1);
++  curl_msnprintf(buf, 3, "%f", MAXIMIZE);
++  errors += strlen_check(buf, 2);
++  curl_msnprintf(buf, 4, "%f", MAXIMIZE);
++  errors += strlen_check(buf, 3);
++  curl_msnprintf(buf, 5, "%f", MAXIMIZE);
++  errors += strlen_check(buf, 4);
++  curl_msnprintf(buf, 6, "%f", MAXIMIZE);
++  errors += strlen_check(buf, 5);
++
++  if(!errors)
++    printf("All float strings tests OK!\n");
++  else
++    printf("test_float_formatting Failed!\n");
++
++  return errors;
++}
+ 
+ int test(char *URL)
+ {
+@@ -1394,6 +1546,8 @@
+ 
+   errors += test_curl_off_t_formatting();
+ 
++  errors += test_float_formatting();
++
+   if(errors)
+     return TEST_ERR_MAJOR_BAD;
+   else

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -20,6 +20,10 @@
 20_CVE-2015-3143.patch
 21_CVE-2015-3148-1.patch
 22_CVE-2015-3148-2.patch
+# wheezy 14
+CVE-2016-5419.patch
+CVE-2016-5420.patch
 
+# Patches at the end
 90_gnutls.patch
 99_nss.patch

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -27,6 +27,18 @@ CVE-2016-5420.patch
 CVE-2016-7141.patch
 # wheezy 16
 CVE-2016-7167.patch
+# wheezy 17
+CVE-2016-8615.patch
+CVE-2016-8616.patch
+CVE-2016-8617.patch
+CVE-2016-8618.patch
+CVE-2016-8619.patch
+#only used by local user: CVE-2016-8620.patch
+CVE-2016-8621.patch
+CVE-2016-8622.patch
+CVE-2016-8623.patch
+CVE-2016-8624.patch
+#don't change behaviour in Maemo: CVE-2016-8625.patch
 
 # Patches at the end
 90_gnutls.patch

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -23,6 +23,8 @@
 # wheezy 14
 CVE-2016-5419.patch
 CVE-2016-5420.patch
+# wheezy 15
+CVE-2016-7141.patch
 
 # Patches at the end
 90_gnutls.patch

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -25,6 +25,8 @@ CVE-2016-5419.patch
 CVE-2016-5420.patch
 # wheezy 15
 CVE-2016-7141.patch
+# wheezy 16
+CVE-2016-7167.patch
 
 # Patches at the end
 90_gnutls.patch

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -39,6 +39,8 @@ CVE-2016-8622.patch
 CVE-2016-8623.patch
 CVE-2016-8624.patch
 #don't change behaviour in Maemo: CVE-2016-8625.patch
+# wheezy 18
+CVE-2016-9586.patch
 
 # Patches at the end
 90_gnutls.patch


### PR DESCRIPTION
  * Fix CVE-2016-5419: TLS session resumption client cert bypass.
  * Fix CVE-2016-5420: Re-using connection with wrong client cert.
  * Fix CVE-2016-7141: Incorrect reuse of client certificates (Closes:
    #836918)
  * Fix CVE-2016-7167: Curl escape/unescape integer overflows (closes:
    #837945)
  * CVE-2016-8615
    If cookie state is written into a cookie jar file that is later read
    back and used for subsequent requests, a malicious HTTP server can
    inject new cookies for arbitrary domains into said cookie jar.
    The issue pertains to the function that loads cookies into memory, which
    reads the specified file into a fixed-size buffer in a line-by-line
    manner using the `fgets()` function. If an invocation of fgets() cannot
    read the whole line into the destination buffer due to it being too
    small, it truncates the output.
    This way, a very long cookie (name + value) sent by a malicious server
    would be stored in the file and subsequently that cookie could be read
    partially and crafted correctly, it could be treated as a different
    cookie for another server.
  * CVE-2016-8616
    When re-using a connection, curl was doing case insensitive comparisons
    of user name and password with the existing connections.
    This means that if an unused connection with proper credentials exists
    for a protocol that has connection-scoped credentials, an attacker can
    cause that connection to be reused if s/he knows the case-insensitive
    version of the correct password.
  * CVE-2016-8617
    In libcurl's base64 encode function, the output buffer is allocated
    as follows without any checks on insize:
       malloc( insize * 4 / 3 + 4 )
    On systems with 32-bit addresses in userspace (e.g. x86, ARM, x32),
    the multiplication in the expression wraps around if insize is at
    least 1GB of data. If this happens, an undersized output buffer will
    be allocated, but the full result will be written, thus causing the
    memory behind the output buffer to be overwritten.
    Systems with 64 bit versions of the `size_t` type are not affected
    by this issue.
  * CVE-2016-8618
    The libcurl API function called `curl_maprintf()` can be tricked into
    doing a double-free due to an unsafe `size_t` multiplication, on
    systems using 32 bit `size_t` variables. The function is also used
    internallty in numerous situations.
    Systems with 64 bit versions of the `size_t` type are not affected
    by this issue.
  * CVE-2016-8619
    In curl's implementation of the Kerberos authentication mechanism,
    the function `read_data()` in security.c is used to fill the
    necessary krb5 structures. When reading one of the length fields from
    the socket, it fails to ensure that the length parameter passed to
    realloc() is not set to 0.
  * CVE-2016-8621
    The `curl_getdate` converts a given date string into a numerical
    timestamp and it supports a range of different formats and
    possibilites to express a date and time. The underlying date
    parsing function is also used internally when parsing for example
    HTTP cookies (possibly received from remote servers) and it can be
    used when doing conditional HTTP requests.
  * CVE-2016-8622
    The URL percent-encoding decode function in libcurl is called
    `curl_easy_unescape`. Internally, even if this function would be
    made to allocate a unscape destination buffer larger than 2GB, it
    would return that new length in a signed 32 bit integer variable,
    thus the length would get either just truncated or both truncated
    and turned negative. That could then lead to libcurl writing outside
    of its heap based buffer.
  * CVE-2016-8623 9/11 curl Use-after-free via shared cookies
    libcurl explicitly allows users to share cookies between multiple
    easy handles that are concurrently employed by different threads.
    When cookies to be sent to a server are collected, the matching
    function collects all cookies to send and the cookie lock is released
    immediately afterwards. That funcion however only returns a list with
    *references* back to the original strings for name, value, path and so
    on. Therefore, if another thread quickly takes the lock and frees one
    of the original cookie structs together with its strings,
    a use-after-free can occur and lead to information disclosure. Another
    thread can also replace the contents of the cookies from separate HTTP
    responses or API calls.
  * CVE-2016-8624 10/11 curl invalid URL parsing with '#'
    curl doesn't parse the authority component of the URL correctly when
    the host name part ends with a '#' character, and could instead be
    tricked into connecting to a different host. This may have security
    implications if you for example use an URL parser that follows the RFC
    to check for allowed domains before using curl to request them.
  * CVE-2016-9586
    libcurl's implementation of the printf() functions triggers a buffer
    overflow when doing a large floating point output. The bug occurs
    when the conversion outputs more than 255 bytes.
    If there are any application that accepts a format string from the outside
    without necessary input filtering, it could allow remote attacks.
    This flaw does not exist in the command line tool.
    (Closes: #848958)